### PR TITLE
update discourse url to .teia.art

### DIFF
--- a/data/authors/ufffd.md
+++ b/data/authors/ufffd.md
@@ -1,6 +1,6 @@
 ---
 name: ufffd
-avatar: https://discourse.hencommunity.quest/user_avatar/discourse.hencommunity.quest/ufffd/45/13_2.png
+avatar: https://discourse.teia.art/user_avatar/discourse.teia.art/ufffd/45/13_2.png
 occupation: Internet Creative & Glitch Wrangler
 twitter: https://twitter.com/_ufffd
 teia: ufffd

--- a/data/blog/dao-development-update-01.mdx
+++ b/data/blog/dao-development-update-01.mdx
@@ -27,7 +27,7 @@ It has been a long process, but we are soon prepared to start the first phase of
 
 
 **Legal**
-- Finding possible legal pathways to register our DAO as a non profit entity ✅ see also: [Legal discussion writeup on discourse](https://discourse.hencommunity.quest/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)
+- Finding possible legal pathways to register our DAO as a non profit entity ✅ see also: [Legal discussion writeup on discourse](https://discourse.teia.art/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)
 
 **Smartcontract development** 
 - Writing the DAO token smart contract.✅ 
@@ -51,7 +51,7 @@ For this we need your input and feeling about what's fair and reasonable.
 
 ![9639090b-0fc7-4faa-86ff-778d46cabdfe Voting 2020 Election GIF by INTO ACTION](https://user-images.githubusercontent.com/97635650/169689269-d2c2179d-a35c-4a26-b257-209f119feae9.gif)
 
-You can find info about the planed distribution, example modelsand discuss them on our Discourse forum and in the #General-DAO channel on the Teia discord server. [Link to the discourse distribution discussion](https://discourse.hencommunity.quest/t/teia-dao-token-distribution-discussion/605/)
+You can find info about the planed distribution, example modelsand discuss them on our Discourse forum and in the #General-DAO channel on the Teia discord server. [Link to the discourse distribution discussion](https://discourse.teia.art/t/teia-dao-token-distribution-discussion/605/)
 
 Over the next days, we will run a few twitter polls on this twitter account to get general feedback on some distribution parameters. Please note that these won't be official "voting rounds" but supposed to get some general, non-binding feedback. Stay tuned!
 
@@ -90,7 +90,7 @@ Para isso nesse exato momento, precisamos seguir uma longa lista de passos:
 
 **Legal**
 - Encontrando caminhos legais para registrar nossa DAO como uma entidade sem fins lucrativos ✅
-Veja também: https://discourse.hencommunity.quest/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597
+Veja também: https://discourse.teia.art/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597
 
 **Desenvolvimento de Smartcontracts**
 - Escrever o smartcontract da DAO.✅ 
@@ -118,7 +118,7 @@ Para isso nós precisamos da sua opinião sobre o que é justo e faz sentido.
 ![9639090b-0fc7-4faa-86ff-778d46cabdfe Voting 2020 Election GIF by INTO ACTION](https://user-images.githubusercontent.com/97635650/169689269-d2c2179d-a35c-4a26-b257-209f119feae9.gif)
 
 Você pode encontrar mais informação sobre a distribuição planejada, exemplo modelsand discutido no nosso forum Discourse e no canal general-DAO no server da Teia no Discord.
-https://discourse.hencommunity.quest/t/teia-dao-token-distribution-discussion
+https://discourse.teia.art/t/teia-dao-token-distribution-discussion
 
 Pelos próximos dias nós vamos fazer alguma votações na conta do twitter pra ter um feedback geral em alguns dos parâmetros da distribuição. Por favor, note que essas não serão "votações oficiais" mas pra termos um feedback geral não-vinculativo. Fique de olho!
 
@@ -159,7 +159,7 @@ _Translator: Jovi_
 **合法合规**
 
 - 通过合适的法律途径将我们的DAO注册为非盈利实体。 ✅
-详情查看：https://discourse.hencommunity.quest/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597
+详情查看：https://discourse.teia.art/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597
 
 **智能合约开发**
 
@@ -189,7 +189,7 @@ https://github.com/teia-community/teia-docs/wiki/Governance-on-Teia#dao-smart-co
 
 您可以在我们的论坛和TEIA Discord Server上的Genereal-Dao频道上找到相关信息，不同的分发模型和讨论它们。
 
-https://discourse.hencommunity.quest/t/teia-dao-token-distribution-discussion/605/4
+https://discourse.teia.art/t/teia-dao-token-distribution-discussion/605/4
 
 在接下来的几天里，我们将在此Twitter帐户上举行民意调查，以获取有关某些分发参数的反馈。请注意，这不是正式的“投票回合”，敬请关注！
 

--- a/data/blog/marketplace-contract-launch.mdx
+++ b/data/blog/marketplace-contract-launch.mdx
@@ -33,7 +33,7 @@ There is a community vote live on [Teia Vote](https://vote.hencommunity.quest/) 
 
 Swaps/listings done on Teia.art will only be shown on platforms that support/index our marketplace contract. Hic et nunc will not support the Teia swaps, but objkt.com offered to show Teia listing prices/swaps and asked us to show swaps done on objkt.com in return. 
   
-For further information, please refer to the [Discourse thread on the topic](https://discourse.hencommunity.quest/t/teia-art-swaps-and-objkt-com/581)
+For further information, please refer to the [Discourse thread on the topic](https://discourse.teia.art/t/teia-art-swaps-and-objkt-com/581)
 
 cast your vote here (vote runs until 25th of march, 00:00 UTC) 
 [https://vote.hencommunity.quest/vote/QmPDYWmGdxae8gUxqiPa4rkuQCc8P6sggLvUi5HQrrCzug](https://vote.hencommunity.quest/vote/QmPDYWmGdxae8gUxqiPa4rkuQCc8P6sggLvUi5HQrrCzug)

--- a/data/blog/on-chain-naming-vote-fact-sheet.mdx
+++ b/data/blog/on-chain-naming-vote-fact-sheet.mdx
@@ -89,7 +89,7 @@ For this naming vote, every wallet will have the same voting weight of 1 vote pe
 
 > 8.  Who is behind this platform now?
 
-Right after the discontinuation of hicetnunc.xyz on November 11th, 2021, a group of people (initially mainly participants of the first “hicathon” event) joined forces to organize the future of the platform. The main discussion platform is [the new “hen_community” (HENC) discord server](https://discord.gg/cXGymBsE) and the [community discourse forum](https://discourse.hencommunity.quest/). We are currently working on forming a DAO in order to make this platform fully decentralized.
+Right after the discontinuation of hicetnunc.xyz on November 11th, 2021, a group of people (initially mainly participants of the first “hicathon” event) joined forces to organize the future of the platform. The main discussion platform is [the new “hen_community” (HENC) discord server](https://discord.gg/cXGymBsE) and the [community discourse forum](https://discourse.teia.art/). We are currently working on forming a DAO in order to make this platform fully decentralized.
 
 Our main goal for now is is to keep the core values and spirit of hicetnunc alive and keeping the platform accessible to vereyone. The next step will be to update the marketplace smart contract so that the fees can be used to keep the platform running; Currently all platform fees still go to crzypatchwork.
 
@@ -98,7 +98,7 @@ The discord is always open for any kind of participation, and we will continue t
 > 9.  How to participate?
 
 - [You can join the HENC discord here](https://discord.gg/mzmesqw4)
-- You can also participate without joining the discord via the community discourse forum: [discourse.hencommunity.quest](https://discourse.hencommunity.quest/)
+- You can also participate without joining the discord via the community discourse forum: [discourse.teia.art](https://discourse.teia.art/)
 - For updates, you can follow our current twitter account: [@hen_community](https://twitter.com/hen_community) and [our blog (currently under construction)](https://hencommunity.quest/)
 - Volunteer opportunities are available! If you are interested, please fill out [this google form](https://forms.gle/75QHgUC5EZTReceK7) so we can get a overview and start coordinating the working groups: (Note: This is not a prerequisite for participation; Anyone can join and participate, discuss and look up past discussions. )
 

--- a/data/blog/teia-art-launch-announcement.mdx
+++ b/data/blog/teia-art-launch-announcement.mdx
@@ -29,7 +29,7 @@ Teia.art currently uses the HEN v2 contract for swaps, but will switch to the Te
 
 In addition to the new marketplace contract, we have created [a new multisig wallet](https://github.com/jagracar/tezos-smart-contracts/blob/1.0.0/python/contracts/multisignWalletContract.py). This multisig wallet will make it possible for the community to collect platform fees on swaps done on the Teia platform. A team of around 15 people have been given custody of this wallet while we are working on building democratic structures for governing the organization Teia DAO. Please note that this team is in place only to sign transactions that the community decides on, not to form decisions.
 
-The new marketplace website is [teia.art](https://teia.art). We have done our best to maintain cross compatibility with the other versions of Hic et Nunc. Our developers are working with Manitcor (who has been maintaining the hicetnunc.art website - [read some background here](https://discourse.hencommunity.quest/t/hi-im-joe-founder-of-integro-labs-and-teztools-i-will-be-your-custodian-for-this-journey/300)) to make sure that existing links are not broken and maintain cross compatibility wherever possible.
+The new marketplace website is [teia.art](https://teia.art). We have done our best to maintain cross compatibility with the other versions of Hic et Nunc. Our developers are working with Manitcor (who has been maintaining the hicetnunc.art website - [read some background here](https://discourse.teia.art/t/hi-im-joe-founder-of-integro-labs-and-teztools-i-will-be-your-custodian-for-this-journey/300)) to make sure that existing links are not broken and maintain cross compatibility wherever possible.
 
 Minting OBJKTs on Teia will take place with the same smart minting contract ([github.com/hicetnunc2000/objkt-swap](https://github.com/hicetnunc2000/objkt-swap)) that hicetnunc.xyz (and hicetnunc.art) use for their minting function. You will be able to swap your tokens on any platform/mirror that supports OBJKT token trading (like [hicetnunc.xyz](https://www.hicetnunc.xyz/), [hic.af](https://hic.af/), [hen.teztools.io](https://hen.teztools.io/), [henext.xyz](https://www.henext.xyz/) and many more). We are working with [Objkt.com](https://objkt.com/) and [Versum](https://versum.xyz/) to ensure that swaps done on the Teia Community marketplace contract show up properly on these platforms in the future.
 
@@ -39,7 +39,7 @@ We would like to express our appreciation to all community members who have help
 * Blog: [hencommunity.quest/blog](https://hencommunity.quest/blog)    
 * Teia Community Discord ([discord.com/invite/gWtm4eqPKX](https://discord.com/invite/gWtm4eqPKX))    
 * Teia Community Twitter ([@TeiaCommunity](https://twitter.com/TeiaCommunity))
-* Public Community Forum ([discourse.hencommunity.quest](https://discourse.hencommunity.quest/))    
+* Public Community Forum ([discourse.teia.art](https://discourse.teia.art/))    
 * Github ([github.com/teia-community](https://github.com/teia-community))   
 
 (2) If you are interested in volunteering, please visit the "[volunteer-opportunities](https://discord.com/channels/908672304236625970/922115509363818566)" channel in our Discord group and/or fill out the [volunteers form](https://docs.google.com/forms/d/e/1FAIpQLSenb-_1FH3pyeQclVME9Bv12Tc5WzMN6ZYOYoHQckIIMrhjxw/viewform). 

--- a/data/blog/teia-newsletter-001.mdx
+++ b/data/blog/teia-newsletter-001.mdx
@@ -63,7 +63,7 @@ with the new smart contract we need to decide how and if we are going to show ot
 
 the communication with objktcom has started on that, probably the same discussions will come up with other platforms soon.  
 
-[read and discuss the swap support on discourse ](https://discourse.hencommunity.quest/t/teia-art-swaps-and-objkt-com/581)  
+[read and discuss the swap support on discourse ](https://discourse.teia.art/t/teia-art-swaps-and-objkt-com/581)  
 
   
 note that this discussion is **not** about showing other tokens minted on other contracts, like tokens minted on objktcom or versum. those are all different minting contracts and we aren't able to display those, at least for now.
@@ -123,7 +123,7 @@ while we were saving domains and handles during the last voting round, community
 [qizzio](https://twitter.com/qizzio) and [mumuthestan](https://twitter.com/mumu_thestan) developed the idea to use another handle, [@teiaart](https://twitter.com/TeiaArt), for a shared curation experiment: every day a new community member gets access to the account via tweetdeck and can share, quote retweet art or write art curation threads. the number of applications after the first announcement was so high, the form needed to be closed for now unfortunately - but it will be reopened eventually.
 
 
-[read more on the community curation with a lot of translations:](https://discourse.hencommunity.quest/t/teiaart-guest-community-curator-with-translations/577)
+[read more on the community curation with a lot of translations:](https://discourse.teia.art/t/teiaart-guest-community-curator-with-translations/577)
 
 
 
@@ -185,7 +185,7 @@ Con el nuevo contrato inteligente, debemos decidir cómo y si es que vamos a mos
 
 La comunicación en objkt.com ha comenzado ha hablar de eso y probablemente las mismas discusiones surgirán pronto en otras plataformas.
 
-[lee y discute sobre el soporte de swaps en nuestro Discord](https://discourse.hencommunity.quest/t/teia-art-swaps-and-objkt-com/581)
+[lee y discute sobre el soporte de swaps en nuestro Discord](https://discourse.teia.art/t/teia-art-swaps-and-objkt-com/581)
 
 Toma en cuenta que esta discusión no se trata sobre mostrar otros tokens minteados en otros contratos, como tokens minteados en objkt.com o versum. Todos esos son contratos de minteo diferentes y no podemos mostrarlos, al menos por ahora.
 
@@ -227,7 +227,7 @@ Mientras registrábamos dominios web y cuentas en redes durante la última ronda
 
 El número de solicitudes después del primer anuncio fue tan alto que, lamentablemente, el formulario debió cerrarse por ahora, pero se reabrirá eventualmente.
 
-[lee más sobre curaduría comunitaria, con muchas traducciones](https://discourse.hencommunity.quest/t/teiaart-guest-community-curator-with-translations/577)
+[lee más sobre curaduría comunitaria, con muchas traducciones](https://discourse.teia.art/t/teiaart-guest-community-curator-with-translations/577)
 
   
   

--- a/data/blog/teia-newsletter-003.mdx
+++ b/data/blog/teia-newsletter-003.mdx
@@ -63,7 +63,7 @@ https://teia.rocks/ is an alternative mirror which has been set up independently
 
 ## Teia marketplace contract and DAO registration
 
-The legal team has continued researching our legal situation and looked for ways to go forward in terms of incorporating Teia. [you can read a summary of the current discussion on our discourse forum](https://discourse.hencommunity.quest/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)
+The legal team has continued researching our legal situation and looked for ways to go forward in terms of incorporating Teia. [you can read a summary of the current discussion on our discourse forum](https://discourse.teia.art/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)
 
 The main consensus is that we should incorporate Teia as soon as possible in order to have legal clarity and protection. We are currently in touch with DAO specialists and trying to sort out the best way to register as a DAO, currently a good option would be to register Teia in the Republic of Marshall Islands as they allow registration as DAO with a smartcontract defining the members of the entity.
 

--- a/data/blog/teia-newsletter-004.mdx
+++ b/data/blog/teia-newsletter-004.mdx
@@ -28,7 +28,7 @@ Please understand that there might be some delays and troubleshooting over the n
 
 ## Voting On Showing Swaps From Objkt.com
 
-Having the new swapping contract in place means that we have to decide if we want to display swaps done on other marketplaces on [teia.art](http://teia.art). Along with this, we can start asking other marketplaces that display OBJKTs to show our swaps on their end. For further information, please refer to the [Discourse thread on the topic](https://discourse.hencommunity.quest/t/teia-art-swaps-and-objkt-com/581). Please note that we are still using the same minting contract as hicetnunc, so for now, teia OBJKTs are the same as HEN OBJKTs. This means that the OBJKTs minted on Teia show up on all marketplaces that show hicetnunc OBJKTs (i.e. hicetnunc.xyz, objktcom, rarible, [hic.af](http://hic.af/), etc). This won’t change no matter which platform supports which swapping contract. The swapping contract is the mechanism for listing OBJKTs for sale at a specific price and quantity. 
+Having the new swapping contract in place means that we have to decide if we want to display swaps done on other marketplaces on [teia.art](http://teia.art). Along with this, we can start asking other marketplaces that display OBJKTs to show our swaps on their end. For further information, please refer to the [Discourse thread on the topic](https://discourse.teia.art/t/teia-art-swaps-and-objkt-com/581). Please note that we are still using the same minting contract as hicetnunc, so for now, teia OBJKTs are the same as HEN OBJKTs. This means that the OBJKTs minted on Teia show up on all marketplaces that show hicetnunc OBJKTs (i.e. hicetnunc.xyz, objktcom, rarible, [hic.af](http://hic.af/), etc). This won’t change no matter which platform supports which swapping contract. The swapping contract is the mechanism for listing OBJKTs for sale at a specific price and quantity. 
 
 A suggestion raised earlier on our Discord was to ask objktcom to show swaps done on Teia if we showed swaps done on their platform. This idea was brought to objktcom and they agreed that this would be a viable option. Please note that NFTs minted through objktcom will not be visible on Teia, since these are a different type of token.
 
@@ -67,7 +67,7 @@ Another step is determining the distribution of new Teia DAO tokens (currently b
 
 ### Registration Roadmap
 
-You can find a detailed summary of [discussion regarding the registration of the Teia DAO on this Discourse Thread](https://discourse.hencommunity.quest/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)
+You can find a detailed summary of [discussion regarding the registration of the Teia DAO on this Discourse Thread](https://discourse.teia.art/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)
 
 The discussions indicate this possible roadmap for the incorporation of Teia forming: 
 
@@ -171,7 +171,7 @@ Teia 社区正在继续进行 Teia 开发：在过去的几天里，Teia 向前�
 
 ## 投票显示来自 Objkt.com 的掉期
 
-有了新的市场合约意味着我们必须决定是否要在[teia.art](http://teia.art/)上显示在其他市场上完成的交换。除此之外，我们可以开始要求其他显示 OBJKT 的市场显示我们的掉期。有关详细信息，请参阅[有关该主题的 Discourse 线程](https://discourse.hencommunity.quest/t/teia-art-swaps-and-objkt-com/581)。请注意，我们仍然使用与 hicetnunc 相同的铸币合约，因此目前，teia OBJKT 与 HEN OBJKT 相同。这意味着在 Teia 上铸造的 OBJKT 会出现在所有显示 hicetnunc OBJKT 的市场上（即 hicetnunc.xyz、objktcom、rarible、[hic.af](http://hic.af/)， 等等）。无论哪个平台支持哪个交换合约，这都不会改变。交换合约是列出 OBJKT 以特定价格和数量出售的机制。
+有了新的市场合约意味着我们必须决定是否要在[teia.art](http://teia.art/)上显示在其他市场上完成的交换。除此之外，我们可以开始要求其他显示 OBJKT 的市场显示我们的掉期。有关详细信息，请参阅[有关该主题的 Discourse 线程](https://discourse.teia.art/t/teia-art-swaps-and-objkt-com/581)。请注意，我们仍然使用与 hicetnunc 相同的铸币合约，因此目前，teia OBJKT 与 HEN OBJKT 相同。这意味着在 Teia 上铸造的 OBJKT 会出现在所有显示 hicetnunc OBJKT 的市场上（即 hicetnunc.xyz、objktcom、rarible、[hic.af](http://hic.af/)， 等等）。无论哪个平台支持哪个交换合约，这都不会改变。交换合约是列出 OBJKT 以特定价格和数量出售的机制。
 
 早些时候在我们的 Discord 上提出的一个建议是，如果我们在他们的平台上显示交换完成，请让 objktcom 显示在 Teia 上完成的交换。这个想法被带到了 objktcom，他们同意这将是一个可行的选择。请注意，通过 objktcom 铸造的 NFT 在 Teia 上不可见，因为它们是不同类型的代币。
 
@@ -203,7 +203,7 @@ Teia 现在有了自己独特的外观！对 hicetnunc 用户界面的 UI 更改
 
 ### 注册路线图
 
-[您可以在此 Discourse Thread 上找到有关 Teia DAO 注册的](https://discourse.hencommunity.quest/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)详细讨论摘要
+[您可以在此 Discourse Thread 上找到有关 Teia DAO 注册的](https://discourse.teia.art/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597)详细讨论摘要
 
 讨论表明了 Teia 成型合并的可能路线图：
 

--- a/data/blog/teia-newsletter-005.mdx
+++ b/data/blog/teia-newsletter-005.mdx
@@ -63,7 +63,7 @@ If you want to report/ask/share/discuss suspicious events or behaviour, please g
 
 Before we can initiate the distribution of Governance tokens there remain [several open questions to be resolved](https://github.com/teia-community/teia-docs/wiki/Governance-on-Teia#open-questions-and-tasks-for-the-dao-implementation); such as “how many governance tokens to mint?”, “what role will existing hDAO tokens play?”, “how will user activity on teia/HEN be weighted for additional token distribution?”, “which voting model will we use?”. 
 
-You can find an in-depth writeup of the current state of the DAO development on the [Governance on Teia article on our wiki](https://github.com/teia-community/teia-docs/wiki/Governance-on-Teia#dao-smart-contract-development) and if you have thoughts, please share them in discord or in our [discourse forum](https://discourse.hencommunity.quest/).  
+You can find an in-depth writeup of the current state of the DAO development on the [Governance on Teia article on our wiki](https://github.com/teia-community/teia-docs/wiki/Governance-on-Teia#dao-smart-contract-development) and if you have thoughts, please share them in discord or in our [discourse forum](https://discourse.teia.art/).  
 
 We are **looking for frontent Devs and UI designers** that can help developing UIs for the different sites that will be needed for our DAO governance. If you want to be involved in building these sites for the DAO, please join the #general-dao channel and the [dedicated DAO Frontend Thread](https://discord.com/channels/908672304236625970/960683387335630878/960683742551216128) on our community discord and say hello. 
 
@@ -83,7 +83,7 @@ Additionally, the grants and awards team is looking into applying for a tezos fo
 
 ### Teia registration roadmap
 
-As these questions are being discussed, we will also research the process of registering Teia as a legally acknowledged DAO with the assistance of [MIDAO Directory Services](https://twitter.com/MIDAODS). Once the details are more definite, we will prepare and share a roadmap for the DAO. [Find more details about the Legal discussion on discourse.](https://discourse.hencommunity.quest/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597#registering-a-dao-in-the-marshall-islands-rmi-13)
+As these questions are being discussed, we will also research the process of registering Teia as a legally acknowledged DAO with the assistance of [MIDAO Directory Services](https://twitter.com/MIDAODS). Once the details are more definite, we will prepare and share a roadmap for the DAO. [Find more details about the Legal discussion on discourse.](https://discourse.teia.art/t/discussion-writeup-the-legal-roadmap-for-teia-next-steps/597#registering-a-dao-in-the-marshall-islands-rmi-13)
 
 We want to make sure that we don’t collect any fees into the multisig wallet until we have an approved and clear roadmap to DAO registration. This is to avoid the risk of staying unregistered because of a lack of consensus.
 

--- a/data/blog/teia-newsletter-007.mdx
+++ b/data/blog/teia-newsletter-007.mdx
@@ -21,7 +21,7 @@ We are proceeding towards our DAO launch - the contracts are ready and tested. W
 
 Over the next few days we will run some twitter polls to get some general, non-binding, feedback on the token drop parameters; and invite the whole community to join the discussion.
 
-Hop into the #🦋general-dao channel on the Teia Discord server to discuss and comment on the [DAO distribution discourse thread](https://discourse.hencommunity.quest/t/teia-dao-token-distribution-discussion/605). 
+Hop into the #🦋general-dao channel on the Teia Discord server to discuss and comment on the [DAO distribution discourse thread](https://discourse.teia.art/t/teia-dao-token-distribution-discussion/605). 
 
 A more detailed [write-up of the state of the DAO development can be read on our wiki](https://github.com/teia-community/teia-docs/wiki/Governance-on-Teia).
 
@@ -197,7 +197,7 @@ If you have a skill or area of interest not listed here, feel free to jump into 
 
 ## Statement by Manitcor of TezTools
 
-Manitcor, founder of Teztools and is currently the hired infra backbone of the Teia Marketplace [since the beginning of the project](https://discourse.hencommunity.quest/t/hi-im-joe-founder-of-integro-labs-and-teztools-i-will-be-your-custodian-for-this-journey/300), will start as Vice President of Engineering Blockchain at Tezos music NFT marketplace  🔗 Oneof. He wants to be open about that involvement and the possible implications of him working for Oneof and Teia at the same time. Oneof has been very helpful towards Teia so far: There have been larger monetary donations towards our project by Oneof and in November, OneOf opened their space at the Tezos Miami event to members of our community. 
+Manitcor, founder of Teztools and is currently the hired infra backbone of the Teia Marketplace [since the beginning of the project](https://discourse.teia.art/t/hi-im-joe-founder-of-integro-labs-and-teztools-i-will-be-your-custodian-for-this-journey/300), will start as Vice President of Engineering Blockchain at Tezos music NFT marketplace  🔗 Oneof. He wants to be open about that involvement and the possible implications of him working for Oneof and Teia at the same time. Oneof has been very helpful towards Teia so far: There have been larger monetary donations towards our project by Oneof and in November, OneOf opened their space at the Tezos Miami event to members of our community. 
 
 Here is a statement by Manitcor (taken from the Teia Discord server)
 

--- a/data/blog/teia-newsletter-009.mdx
+++ b/data/blog/teia-newsletter-009.mdx
@@ -19,7 +19,7 @@ Another month, another newsletter from the Teia lands, stuffed with news around 
 
 ## Defining the Next Steps for Teia’s Development
 
-A lot of ideas for improving Teia’s code and UX have been brought forth and discussed. Since we do not yet have a fully developed DAO structure, the Dev Team is currently discussing these points and deciding on a rough roadmap in regards to Indexer and IPFS solutions (which will be the next areas of improvement). The community is always welcome to join the discussions in the Dev channels on [Discord](https://discord.gg/4epTJeuu) and [discourse](https://discourse.hencommunity.quest); any input on these subjects is highly appreciated.
+A lot of ideas for improving Teia’s code and UX have been brought forth and discussed. Since we do not yet have a fully developed DAO structure, the Dev Team is currently discussing these points and deciding on a rough roadmap in regards to Indexer and IPFS solutions (which will be the next areas of improvement). The community is always welcome to join the discussions in the Dev channels on [Discord](https://discord.gg/4epTJeuu) and [discourse](https://discourse.teia.art); any input on these subjects is highly appreciated.
 
 ### Improving Loading Speed via Thumbnails
 
@@ -37,7 +37,7 @@ Since Xat wants to apply for a Tezos Foundation Grant for TezTok, he proposed to
 
 Of course there are counter arguments to consider, the main one being that TezTok is not using one of the well documented and widely used frameworks like dipdup that make contribution easier. However, one part of the proposal is adding better documentation to make working with the TezTok software easier for contributors.
 
-If you have questions about this, feel free to join the discussion on our discourse forum. You can also find more detailed info about this proposal in the [discourse thread for the proposal](https://discourse.hencommunity.quest/t/proposal-teztok-integration/613)
+If you have questions about this, feel free to join the discussion on our discourse forum. You can also find more detailed info about this proposal in the [discourse thread for the proposal](https://discourse.teia.art/t/proposal-teztok-integration/613)
 
 By the way: Teia switching to Teztok doesn’t mean that hicdex will be switched off: Hicdex developer [Marchingsquare](https://twitter.com/marchingsquare) shared that he plans to maintain [hicdex.com](http://hicdex.com) in any case in order to keep OBJKTs that rely on it operational. This decision is only about the main indexer used for the Teia marketplace.
 
@@ -55,7 +55,7 @@ Currently, Teia is all about OBJKTs minted through hicetnunc’s minting contrac
 
 However, those new tokens would not work with tools built on hicdex as it currently works. A new Token would mean Teia would start a new ecosystem around the Teia-specific Token. This topic is being discussed now, but it is not on the top of the priority list. (Our current top priorities are improving file loading speed, building the DAO, updating the indexers, finding a IPFS solution, and improving the UI.)
 
-Find and join the discussion around new Token contracts in [this discourse thread](https://discourse.hencommunity.quest/t/new-minting-fa2-contracts-for-teia-discussion/611)
+Find and join the discussion around new Token contracts in [this discourse thread](https://discourse.teia.art/t/new-minting-fa2-contracts-for-teia-discussion/611)
 
 ## DAO Building Process Update
 

--- a/data/blog/the-communication-the-community-and-you.mdx
+++ b/data/blog/the-communication-the-community-and-you.mdx
@@ -91,7 +91,7 @@ cons
 
 ### Discourse/community forum
 
-In addition to Discord, we have our [community forum](https://discourse.hencommunity.quest/) as a place for discussion acting as a “community soapbox” so to speak where people prepare more thought out texts and “speeches” to contribute to the discussion. Here, every idea or topic gets a specific post thread which helps with keeping track and finding the right info. it also is in the hands of the community - as opposed to discord which is run by a third party company (discord, duh)  
+In addition to Discord, we have our [community forum](https://discourse.teia.art/) as a place for discussion acting as a “community soapbox” so to speak where people prepare more thought out texts and “speeches” to contribute to the discussion. Here, every idea or topic gets a specific post thread which helps with keeping track and finding the right info. it also is in the hands of the community - as opposed to discord which is run by a third party company (discord, duh)  
   
 pros
 

--- a/data/linksData.js
+++ b/data/linksData.js
@@ -21,7 +21,7 @@ const linksData = [
     title: 'Teia Discourse',
     description: `A forum space for long form discussion and planning.`,
     imgSrc: '/static/images/discourse-rectangle.png',
-    href: 'https://discourse.hencommunity.quest',
+    href: 'https://discourse.teia.art',
   },
   {
     title: 'Teia.art Wiki',

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -31,7 +31,7 @@ const siteMetadata = {
     // https://vercel.com/docs/environment-variables
     provider: 'discourse', // supported providers: discourse, giscus, utterances, disqus
     discourseConfig: {
-      url: 'https://discourse.hencommunity.quest/',
+      url: 'https://discourse.teia.art/',
       user: 'blogbot',
       threadTerm: 'url', // supported options: url, topic (not implemented yet)
     },

--- a/next.config.js
+++ b/next.config.js
@@ -4,14 +4,14 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
-  default-src 'self' discourse.hencommunity.quest;
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app discourse.hencommunity.quest;
+  default-src 'self' discourse.teia.art;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app discourse.teia.art;
   style-src 'self' 'unsafe-inline' *.googleapis.com cdn.jsdelivr.net;
   img-src * blob: data:;
   media-src 'none';
   connect-src *;
   font-src 'self' fonts.gstatic.com cdn.jsdelivr.net;
-  frame-src giscus.app discourse.hencommunity.quest
+  frame-src giscus.app discourse.teia.art
 `
 
 const securityHeaders = [


### PR DESCRIPTION
commited with no-verify to skip the pre-commit linting. the linter should probably be removed, or updated to not break content. I think it was specifically breaking on the twitter embed.